### PR TITLE
chore: add CODEOWNERS for Copilot code review requirement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# High-Command Code Owners
+# Require Copilot code review on all PRs
+
+* @github-copilot


### PR DESCRIPTION
Add .github/CODEOWNERS to require Copilot code review on all PRs to main.