### PR TITLE
fix: correct dev target dependency chain in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ venv:
 install: venv
 	$(PIP) install -e .
 
-dev: venv
+dev: install
 	$(PIP) install -e ".[dev]"
 
 run:


### PR DESCRIPTION
## Description
Fixed the `make dev` target in the Makefile to properly depend on the `install` target instead of just `venv`.

## Changes
- Changed `dev: venv` to `dev: install` 
- This ensures the base dependencies are installed before installing dev dependencies
- Fixes the issue where `make dev` would fail if base packages weren't installed

## Why This Fix?
The dev extra in `pyproject.toml` includes development tools like pytest, black, ruff, and mypy, but the `[dev]` extra group doesn't include the base dependencies. By making `dev` depend on `install`, we ensure the proper dependency chain:
1. `venv` - Create virtual environment
2. `install` - Install base package and dependencies
3. `dev` - Install additional dev-only dependencies on top

## Testing
- Ran `make dev` successfully
- All dependencies installed correctly