### PR TITLE
docs: add comprehensive rate limiting documentation with exponential backoff details

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,19 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## API Rate Limiting
 
-The Helldivers 2 API has rate limiting. Be respectful in your requests. The MCP server implements reasonable defaults and handles errors gracefully.
+The High-Command API implements **automatic exponential backoff** for rate limiting:
+
+- ✅ **Automatic retries** - Handles 429 (rate limit) responses transparently
+- ✅ **Exponential backoff** - Delays: 5s → 10s → 20s → 40s → 80s
+- ✅ **Up to 5 attempts** - Fails gracefully after exhausting retries
+- ✅ **Transparent to users** - No special handling needed in your code
+
+**Best practices:**
+1. Cache results locally when possible
+2. Avoid making unnecessary requests
+3. Monitor logs for repeated rate limit warnings
+
+See [docs/API.md#rate-limiting](docs/API.md#rate-limiting) for detailed information.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description
Updated API documentation to include comprehensive information about the new exponential backoff feature for rate limiting in the High-Command API.

## Changes

### `docs/API.md`
- Added new **Rate Limiting** section with subsections:
  - **Automatic Exponential Backoff** - Explains the 429 handling strategy
  - **Backoff Strategy** - Documents the 5s → 10s → 20s → 40s → 80s delays
  - **Example Timeline** - Shows what happens across 6 retry attempts
  - **Rate Limiting is Transparent** - Explains automatic handling
  - **Example Code** - Demonstrates how to handle rate limit responses
  - **Best Practices** - Recommendations for respecting the API
  - **Configuration** - Details about backoff settings (5s base, 5 attempts, ~155s max)

### `README.md`
- Enhanced **API Rate Limiting** section with:
  - 4 bullet points highlighting automatic features
  - Best practices for handling rate limits
  - Link to detailed documentation

## Why These Changes?
The High-Command API (from high-command-api repo, PR #9) recently implemented exponential backoff for rate limiting. Users need to understand:
- This feature exists and handles 429 errors automatically
- How it works (exponential delays, max 5 attempts)
- Best practices for respectful API usage
- Where to find detailed information

## Impact
- 📚 Better documentation for users
- 🔗 Clear reference between README and detailed docs
- 🛡️ Helps users understand automatic resilience
- 💡 Provides code examples for handling errors

See [docs/API.md#rate-limiting](https://github.com/surrealwolf/high-command-mcp/blob/docs/rate-limit-documentation/docs/API.md#rate-limiting) for the detailed Rate Limiting section.