### PR TITLE
ci: use shared GitLab mirror reusable workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,23 +62,12 @@ jobs:
         safety check --json || true
   push-to-gitlab:
     name: Push to GitLab
-    runs-on: ubuntu-latest
+    uses: DataKnifeAI/github-workflows/.github/workflows/reusable-gitlab-mirror-push.yml@main
     needs:
     - test
-    if: always() && needs.test.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Push to GitLab
-      env:
-        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-      run: |
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-        git remote remove gitlab 2>/dev/null || true
-        git remote add gitlab https://gitlab.com/dk-raas/dkai/mcp-servers/high-command-mcp.git
-        git config credential.helper '!f() { echo "username=oauth2"; echo "password=${GITLAB_TOKEN}"; }; f'
-        git fetch gitlab main
-        git push gitlab HEAD:main --force
+    if: >-
+      always() && needs.test.result == 'success' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
+    secrets: inherit
+    with:
+      gitlab_mirror_path: dk-raas/dkai/mcp-servers/high-command-mcp


### PR DESCRIPTION
Replaces inline GitLab mirror shell with the shared reusable workflow [reusable-gitlab-mirror-push.yml](https://github.com/DataKnifeAI/github-workflows/blob/main/.github/workflows/reusable-gitlab-mirror-push.yml) from [DataKnifeAI/github-workflows](https://github.com/DataKnifeAI/github-workflows).

**Merge [github-workflows PR #2](https://github.com/DataKnifeAI/github-workflows/pull/2) to `main` first** so `@main` resolves for the reusable workflow and the `push-gitlab-mirror` composite action.

Game server mirror workflows pin `reusable-game-server-mirror.yml` to `@main` so the push step uses the shared action after that merge.